### PR TITLE
Fix client download and news URLs.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "VircadiaLauncher",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "productName": "Vircadia Launcher",
   "author": {
     "name": "Kalila L.",

--- a/pantheon.config.js
+++ b/pantheon.config.js
@@ -10,7 +10,7 @@
 
 module.exports = {
     'cdn': {
-        'root': 'https://cdn.vircadia.com',
+        'root': 'https://api.github.com/repos/vircadia/vircadia/releases',
         'eventsFilename': 'vircadiaEvents.json',
         'metadataFilename': 'vircadiaMeta.json'
     },

--- a/src/background.js
+++ b/src/background.js
@@ -712,7 +712,7 @@ async function silentInstall(useOldInstaller) {
     var vircadiaMetaJSON = await download.cdn.meta();
     var executableLocation; // This is the downloaded installer.
     var installPath; // This is the location to install the application to.
-    var installFolderName = "\\" + versionPaths.toPath(vircadiaMetaJSON.latest) + "\\";
+    var installFolderName = "\\" + versionPaths.toPath(vircadiaMetaJSON[0]) + "\\";
     console.info("silentInstall: installFolderName:", installFolderName);
     var executablePath; // This is the location that the installer exe is located in after being downloaded.
     var exeLocToInstall; // This is what gets installed.
@@ -808,7 +808,7 @@ async function silentInstall(useOldInstaller) {
                     console.info("Running post-install.");
                     // postInstall();
                     win.webContents.send('silent-installer-complete', {
-                        "name": vircadiaMetaJSON.latest.name,
+                        "name": vircadiaMetaJSON[0].tag_name,
                         "folder": installPath,
                     });
                 }
@@ -835,8 +835,8 @@ async function silentInstall(useOldInstaller) {
 //         var vircadiaPackageJSON = 
 //         {
 //             "package": {
-//                 "name": vircadiaMetaJSON.latest.name,
-//                 "version": vircadiaMetaJSON.latest.version
+//                 "name": vircadiaMetaJSON[0].name,
+//                 "version": vircadiaMetaJSON[0].tag_name
 //             }
 //         };
 // 
@@ -858,7 +858,7 @@ async function silentInstall(useOldInstaller) {
 //         }
 // 
 //         var postInstallPackage = {
-//             "name": vircadiaMetaJSON.latest.name,
+//             "name": vircadiaMetaJSON[0].name,
 //             "folder": installPath,
 //         }
 // 
@@ -1041,14 +1041,14 @@ ipcMain.on('download-vircadia', async (event, arg) => {
                 var md5current = hasha.fromFileSync(previousInstaller, {algorithm: 'md5'});
                 md5current = md5current.toUpperCase();
                 
-                if (md5current === vircadiaMetaJSON.latest.md5) {
+                if (md5current === vircadiaMetaJSON[0].md5) {
                     silentInstall(true);
                     return;
                 } else {
                     fs.unlink(previousInstaller, (err) => {
                         if (err) console.log("No previous installation to delete.");
                         console.info(installerName, 'was deleted prior to downloading.');
-                        console.info("Latest Live MD5:", vircadiaMetaJSON.latest.md5);
+                        console.info("Latest Live MD5:", vircadiaMetaJSON[0].md5);
                         console.info(installerName, "MD5:", md5current);
                     });
                 }
@@ -1066,7 +1066,7 @@ ipcMain.on('download-vircadia', async (event, arg) => {
 				onProgress: currentProgress => {
 					console.info(currentProgress);
 					var percent = currentProgress.percent;
-                    if (electronDlItemMain && electronDlItemMain.getURL() === downloadURL) {
+                    if (electronDlItemMain && electronDlItemMain.getURL()) {
                         win.webContents.send('download-installer-progress', {
                             percent
                         });

--- a/src/background.js
+++ b/src/background.js
@@ -441,8 +441,27 @@ async function checkRunningApps() {
 
 async function getDownloadURL() {
     var metaJSON = await download.cdn.meta();
-    if (metaJSON) {
-        return metaJSON.latest.url;
+
+    /*
+    GitHub provides releases in the following format:
+    metaJSON                                    -> A list of all releases.
+    metaJSON[0]                                 -> Latest release.
+    metaJSON[0].assets                          -> A list of downloadable assets (installers, etc) for the latest release.
+    metaJSON[0].assets[0].browser_download_url  -> The download link for the first asset in the list.
+
+    Since the assets list could contain any number of files in any order, we need to search through the list until we find the windows installer.
+    The windows installer will be demarcated by its content type: 'application/x-msdownload'.
+    */
+
+    let latest_url = false;
+    metaJSON[0].assets.forEach((asset) => {
+        if (asset.content_type === 'application/x-msdownload') {
+            latest_url = asset.browser_download_url;
+        }
+    });
+    
+    if (metaJSON && latest_url) {
+        return latest_url;
     } else {
         return false;
     }

--- a/src/background.js
+++ b/src/background.js
@@ -393,14 +393,15 @@ async function checkForInterfaceUpdates() {
     console.info("interfacePackage", interfacePackage);
     console.info("vircadiaMeta", vircadiaMeta);
 
-    if (vircadiaMeta && vircadiaMeta.latest.version && interfacePackage && interfacePackage.version) {
-        var versionCompare = compareVersions(vircadiaMeta.latest.version, cleanedLocalMeta);
+    if (vircadiaMeta && vircadiaMeta[0].tag_name && interfacePackage && interfacePackage.version) {
+        let latestVersion = vircadiaMeta[0].tag_name;
+        var versionCompare = compareVersions(latestVersion, cleanedLocalMeta);
         console.info("Compare Versions:", versionCompare);
         if (versionCompare == 1) {
-            return { "updateAvailable": true, "latestVersion": vircadiaMeta.latest.version };
+            return { "updateAvailable": true, "latestVersion": latestVersion };
         } else {
             // Version check failed, interface is either equal to or above the server's version.
-            return { "updateAvailable": false, "latestVersion": vircadiaMeta.latest.version };
+            return { "updateAvailable": false, "latestVersion": latestVersion };
         }
     } else {
         // Failed to retrieve either or both the server meta and interface meta .JSON files.

--- a/src/components/News.vue
+++ b/src/components/News.vue
@@ -15,7 +15,7 @@
                 class="fill-container"
                 fluid
             >
-                <iframe id="mainIframe" src="https://vircadia.com/launcher-news/" style="width: 100%; height: 100%;"></iframe> 
+                <iframe id="mainIframe" src="https://vircadia.com/news/" style="width: 100%; height: 100%;"></iframe> 
             </v-container>
         </v-main>
     </v-app>

--- a/src/electron_modules/networking/download.js
+++ b/src/electron_modules/networking/download.js
@@ -17,7 +17,7 @@ var electronDlItemMeta = null;
 var electronDlItemEvents = null;
 
 async function getCDNMetaJSON() {
-	var metaURL = DEFAULT_CDN_URL + '/dist/launcher/' + DEFAULT_CDN_METADATA_FILENAME;
+	var metaURL = DEFAULT_CDN_URL;
 		
 	await electronDlMeta.download(win, metaURL, {
 		directory: storagePath.main,


### PR DESCRIPTION
- Changed the download URL for the latest Vircadia client release from [`https://cdn.vircadia.com`](https://cdn.vircadia.com/) to [`https://api.github.com/repos/vircadia/vircadia/releases`](https://api.github.com/repos/vircadia/vircadia/releases).
- Point the news iframe to the correct URL on the new website ([`https://vircadia.com/news/`](https://vircadia.com/news/)).