### PR TITLE
Fix compatibility issue.

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -96,6 +96,7 @@ function createWindow () {
 		resizable: false,
 		webPreferences: {
 			nodeIntegration: true,
+			contextIsolation: false,
 			devTools: true,
             // webSecurity: false
 		} 


### PR DESCRIPTION
`webPreferences.contextIsolation: false` is needed to use `require()` in Electron 12 and up.